### PR TITLE
Bugfix for generated stored columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SELECT hex(md5("a", "b", "c"));    -- also identical
 Tested compatibility
 -------------
 
-OpenSSL v1.1
+OpenSSL v3.0.2
 
-SQLite v3.16
+SQLite v3.37.2
 

--- a/digest.c
+++ b/digest.c
@@ -121,11 +121,11 @@ int sqlite3_digest_init(sqlite3 *db, char **err, const sqlite3_api_routines *api
 {
 	SQLITE_EXTENSION_INIT2(api);
 	OpenSSL_add_all_digests();
-	sqlite3_create_function(db, "digest", -1, SQLITE_ANY, NULL, sqlite3_digest,      NULL, NULL);
-	sqlite3_create_function(db, "sha1",   -1, SQLITE_ANY, NULL, sqlite3_digest_sha1, NULL, NULL);
-	sqlite3_create_function(db, "sha256", -1, SQLITE_ANY, NULL, sqlite3_digest_sha256,  NULL, NULL);
-	sqlite3_create_function(db, "sha512", -1, SQLITE_ANY, NULL, sqlite3_digest_sha512,  NULL, NULL);
-	sqlite3_create_function(db, "md5",    -1, SQLITE_ANY, NULL, sqlite3_digest_md5,  NULL, NULL);
+	sqlite3_create_function(db, "digest", -1, SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC, NULL, sqlite3_digest,      NULL, NULL);
+	sqlite3_create_function(db, "sha1",   -1, SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC, NULL, sqlite3_digest_sha1, NULL, NULL);
+	sqlite3_create_function(db, "sha256", -1, SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC, NULL, sqlite3_digest_sha256,  NULL, NULL);
+	sqlite3_create_function(db, "sha512", -1, SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC, NULL, sqlite3_digest_sha512,  NULL, NULL);
+	sqlite3_create_function(db, "md5",    -1, SQLITE_INNOCUOUS|SQLITE_DETERMINISTIC, NULL, sqlite3_digest_md5,  NULL, NULL);
 	return SQLITE_OK;
 }
 

--- a/tests.sql
+++ b/tests.sql
@@ -1,5 +1,12 @@
 .load ./digest.so
-CREATE TABLE tests (input TEXT, sha TEXT, md TEXT);
+
+CREATE TABLE tests (
+	input TEXT,
+	sha TEXT,
+	md TEXT,
+	gen_md TEXT GENERATED ALWAYS AS (hex(digest('md5', input))) STORED
+);
+
 INSERT INTO tests VALUES 
 	("abc", "A9993E364706816ABA3E25717850C26C9CD0D89D", "900150983CD24FB0D6963F7D28E17F72"),
 	("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84983E441C3BD26EBAAE4AA1F95129E5E54670F1", "8215EF0796A20BCAAAE116D3876C664A");
@@ -8,4 +15,4 @@ SELECT input FROM tests WHERE
 	hex(sha1(input)) != sha OR
 	hex(md5(input)) != md OR
 	hex(digest("sha1", input)) != sha OR
-	hex(digest("md5", input)) != md;
+	gen_md != md;


### PR DESCRIPTION
# Nondeterministic digest functions not allowed inside expressions for generated stored columns

#3 

This PR fixes a bug in the implementation of the digest functions that prevents them from being used inside expressions for generated stored columns.

## Testing

### Confirm issue in `master`

Check out `git checkout bugfix/generated-stored-columns-require-deterministic` branch, check out `digest.c` from `master`, build and run the tests.

```console
$ git checkout bugfix/generated-stored-columns-require-deterministic
Switched to branch 'bugfix/generated-stored-columns-require-deterministic'
$ git checkout master digest.c
Updated 1 path from 409dab5
$ make
cc digest.c -shared -o digest.so -fPIC -pedantic -Wall -lcrypto -DSQLITE_DIGEST_STANDALONE
$ make tests
sqlite3 -line :memory: '.read tests.sql'
Parse error near line 3: non-deterministic functions prohibited in generated columns
  ,  md TEXT,  gen_md TEXT GENERATED ALWAYS AS (hex(digest('md5', input))) STORE
                                      error here ---^
Parse error near line 10: no such table: tests
Parse error near line 14: no such table: tests
make: *** [makefile:5: tests] Error 1
```

### Test bugfix

Revert `digest.c` from the bugfix branch, build and run the tests.

```console
$ git checkout bugfix/generated-stored-columns-require-deterministic digest.c
Updated 1 path from 2bfcaea
$ make
cc digest.c -shared -o digest.so -fPIC -pedantic -Wall -lcrypto -DSQLITE_DIGEST_STANDALONE
$ make tests
sqlite3 -line :memory: '.read tests.sql'
```

Tested for
* Ubuntu 20.04.3 LTS
* SQLite 3.37.2, 3.38.0